### PR TITLE
Fix/pypi remote installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 __pycache__/
-clips_source/
 *.py[cod]
 clips/*.c
 *.so
@@ -14,3 +13,6 @@ GTAGS
 *.egg-info/
 *_clips.c
 dist/
+linux_libs/
+examples/
+notebooks/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include version.py LICENSE.txt
+include version.txt
+include LICENSE.txt

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: clips_source clips clipspy
 clips_source:
 	# wget -O clips.zip $(CLIPS_SOURCE_URL)
 	# unzip -jo clips.zip -d clips_source
-	sudo apt-get update
+	-sudo apt-get update
 	apt-get download aura-libclips-dev # Download needed libraries in current directory
 	apt-get download aura-libclips
 
@@ -64,6 +64,8 @@ install: clipspy install-clips
 
 build: clipspy install-clips
 	sudo $(PYTHON) setup.py bdist_wheel
+	# https://clipspy.readthedocs.io/en/latest/#manylinux-wheels
+	# sudo ./manylinux/build-wheels.sh
 
 clean:
 	# -rm clips.zip
@@ -71,3 +73,4 @@ clean:
 	-rm -fr clips_source build dist clipspy.egg-info .eggs .pytest_cache
 	-rm -f /usr/local/lib/libclips.so* # Remove libclips.so libclips.so.6 libclips.so.6.31
 	-rm -fr $(SHARED_INCLUDE_DIR)/clips.h $(SHARED_INCLUDE_DIR)/clips
+	-rm -fr aura_clipspy.egg-info wheelhouse

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,8 @@ flow based on CLIPS and management for scaling up the use of multiple rules engi
 Remark
 ------
 
-    Read the `Auracog Rules User Guide <doc/user_guide/auracog_rules_user_guide.rst>`_ for a description on this functionality.
+    Read the `Auracog Rules User Guide <doc/user_guide/auracog_rules_user_guide.rst>`_ for a description on this \ functionality.
+
 ---------------------
 
 

--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,24 @@ Building from sources
 +++++++++++++++++++++
 
 The provided Makefile takes care of retrieving the CLIPS source code and compiling the Python bindings together with it.
+Also, run a manylinux (CentOS 6) docker container to build a functional self-contained clipspy library with the needed
+system libraries to be installed in a 64 bits linux machine. The steps that should be done are:
+
+1. Build clipspy library.
 
 .. code:: bash
 
-    $ make
-    $ sudo make install
+    $ sudo make build
+
+2. Copy the generated clispy library from **dist** directory to the required repository.
+
+3. Remove generated files to clean local project to return it to the initial state.
+
+.. code:: bash
+
+    $ sudo make clean
+
+
 
 Please check the documentation_ for more information regarding building CLIPSPy from sources.
 

--- a/manylinux/Dockerfile
+++ b/manylinux/Dockerfile
@@ -1,12 +1,16 @@
 FROM quay.io/pypa/manylinux2010_x86_64
 
 RUN yum install -y make unzip wget
+# RUN auditwheel -V
+# auditwheel 3.1.1 crash, downgrade to 3.1.0 https://github.com/pypa/auditwheel/issues/247
+RUN /opt/_internal/tools/bin/pip3 install auditwheel==3.1.0
 
 COPY . /io
 
 WORKDIR /io
 
-RUN make clips_source
+# RUN make clips_source
 RUN make install-clips
+
 
 CMD "./manylinux/build-wheels.sh"

--- a/manylinux/build-wheels.sh
+++ b/manylinux/build-wheels.sh
@@ -3,8 +3,8 @@
 set -e -x
 
 # Compile wheels
-for PYBIN in /opt/python/*/bin; do
-    "${PYBIN}/pip" install cffi nose setuptools
+for PYBIN in /opt/python/cp36*/bin; do
+    "${PYBIN}/pip" install cffi==1.14.3 nose==1.3.7 setuptools==38.5.2
     "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 done
 
@@ -14,7 +14,7 @@ for whl in wheelhouse/*.whl; do
 done
 
 # Install packages and test
-for PYBIN in /opt/python/*/bin; do
-    "${PYBIN}/pip" install clipspy --no-index -f /io/wheelhouse
+for PYBIN in /opt/python/cp36*/bin; do
+    "${PYBIN}/pip" install aura_clipspy --no-index -f /io/wheelhouse
     (cd "$HOME"; "${PYBIN}/nosetests" -v /io/test)
 done


### PR DESCRIPTION
This PR contain:
* Build clipspy library using **manylinux** docker image (CentOS 6) to generate clipspy wheel library with system libraries contained.
* Force python 3.6 version.
* Fix .dockerignore directories.
* Downgrade auditwheel to 3.1.0 version to fix bug from version 3.1.1 released  25th April.
* Add documentation with steps to build in local clipspy.
