### PR TITLE
Add from python 3.5 to 3.9 wheel generation

### DIFF
--- a/manylinux/build-wheels.sh
+++ b/manylinux/build-wheels.sh
@@ -3,7 +3,7 @@
 set -e -x
 
 # Compile wheels
-for PYBIN in /opt/python/cp36*/bin; do
+for PYBIN in /opt/python/cp3*/bin; do
     "${PYBIN}/pip" install cffi==1.14.3 nose==1.3.7 setuptools==38.5.2
     "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 done
@@ -14,7 +14,7 @@ for whl in wheelhouse/*.whl; do
 done
 
 # Install packages and test
-for PYBIN in /opt/python/cp36*/bin; do
+for PYBIN in /opt/python/cp3*/bin; do
     "${PYBIN}/pip" install aura_clipspy --no-index -f /io/wheelhouse
     (cd "$HOME"; "${PYBIN}/nosetests" -v /io/test)
 done


### PR DESCRIPTION
This PR contain:

- Add python 3.X wheel generation (from 3.5 to 3.9)